### PR TITLE
add_spring_support

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,6 +18,11 @@
             <artifactId>nesty-commons</artifactId>
             <version>0.0.2-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>4.2.6.RELEASE</version>
+        </dependency>
 
     </dependencies>
 

--- a/core/src/main/java/org/nesty/core/server/NestyServer.java
+++ b/core/src/main/java/org/nesty/core/server/NestyServer.java
@@ -12,6 +12,8 @@ import org.nesty.core.server.rest.controller.DefaultController;
 import org.nesty.core.server.rest.controller.URLController;
 import org.nesty.core.server.rest.interceptor.Interceptor;
 import org.nesty.core.server.rest.interceptor.InterceptorHelpers;
+import org.nesty.core.server.springplus.ApplicationContextProvider;
+import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -94,7 +96,15 @@ public abstract class NestyServer extends NestyOptionProvider implements Server 
                      * TODO : may be we can indecate the previous {@link org.nesty.commons.annotations.Interceptor} manully
                      *
                      */
-                    interceptors.add((Interceptor) clazz.newInstance());
+
+                    Interceptor wanted;
+                    if (clazz.getAnnotation(Component.class) != null) {
+                        wanted = (Interceptor) ApplicationContextProvider.get(clazz);
+                    } else {
+                        wanted = (Interceptor)clazz.newInstance();
+                    }
+
+                    interceptors.add(wanted);
                 } catch (InstantiationException | IllegalAccessException e) {
                     throw new ControllerRequestMappingException(String.format("%s newInstance() failed %s", clazz.getName(), e.getMessage()));
                 }

--- a/core/src/main/java/org/nesty/core/server/rest/controller/ControllerMethodDescriptor.java
+++ b/core/src/main/java/org/nesty/core/server/rest/controller/ControllerMethodDescriptor.java
@@ -12,6 +12,8 @@ import org.nesty.core.server.rest.HttpContext;
 import org.nesty.core.server.rest.HttpSession;
 import org.nesty.core.server.rest.URLResource;
 import org.nesty.core.server.rest.controller.ControllerMethodDescriptor.MethodParams.AnnotationType;
+import org.nesty.core.server.springplus.ApplicationContextProvider;
+import org.springframework.stereotype.Component;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
@@ -82,7 +84,12 @@ public class ControllerMethodDescriptor {
         }
 
         try {
-            target = clazz.getClazz().newInstance();
+            Class<?> klass = clazz.getClazz();
+            if (klass.getAnnotation(Component.class) != null) {
+                target = ApplicationContextProvider.get(klass);
+            } else {
+                target = klass.newInstance();
+            }
         } catch (InstantiationException | IllegalAccessException ignored) {
             ignored.printStackTrace();
         }

--- a/core/src/main/java/org/nesty/core/server/springplus/ApplicationContextProvider.java
+++ b/core/src/main/java/org/nesty/core/server/springplus/ApplicationContextProvider.java
@@ -1,0 +1,31 @@
+package org.nesty.core.server.springplus;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+/**
+ * Created by adol on 16-9-21.
+ */
+@Component
+public class ApplicationContextProvider implements ApplicationContextAware {
+
+    private static ApplicationContext context;
+
+    public static ApplicationContext getApplicationContext() {
+        return context;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext ac)
+            throws BeansException {
+        if (context == null){
+            context = ac;
+        }
+    }
+
+    public static Object get(Class<?> klass) {
+        return context.getBean(klass);
+    }
+}

--- a/example/src/main/java/org/nesty/example/httpserver/SimpleHttpServer.java
+++ b/example/src/main/java/org/nesty/example/httpserver/SimpleHttpServer.java
@@ -9,7 +9,10 @@ import org.nesty.core.server.protocol.NestyProtocol;
 public class SimpleHttpServer {
 
     public static void main(String[] args) throws ControllerRequestMappingException, InterruptedException {
+        startServer(args, false);
+    }
 
+    public static void startServer(String[] args, boolean withSpringController) throws ControllerRequestMappingException, InterruptedException {
         // 1. create httpserver
         final NestyServer server = AsyncServerProvider.builder().address("127.0.0.1").port(8080)
                 .service(NestyProtocol.HTTP);
@@ -25,6 +28,10 @@ public class SimpleHttpServer {
         server.scanHttpController("com.nesty.test.neptune")
                 .scanHttpController("com.nesty.test.billing")
                 .scanHttpController("org.nesty.example.httpserver.handler");
+
+        if (withSpringController) {
+            server.scanHttpController("org.nesty.example.httpserver.spring");
+        }
 
         // 4. start http server
         if (!server.start())

--- a/example/src/main/java/org/nesty/example/httpserver/spring/Env.java
+++ b/example/src/main/java/org/nesty/example/httpserver/spring/Env.java
@@ -1,0 +1,19 @@
+package org.nesty.example.httpserver.spring;
+
+import org.nesty.example.httpserver.SimpleHttpServer;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+/**
+ * Created by adol on 17-2-24.
+ */
+public class Env {
+    public static void main(String[] args) throws Exception {
+        AnnotationConfigApplicationContext ctx =
+                new AnnotationConfigApplicationContext();
+
+        ctx.register(EnvConfig.class);
+        ctx.refresh();
+
+        SimpleHttpServer.startServer(args, true);
+    }
+}

--- a/example/src/main/java/org/nesty/example/httpserver/spring/EnvConfig.java
+++ b/example/src/main/java/org/nesty/example/httpserver/spring/EnvConfig.java
@@ -1,0 +1,22 @@
+package org.nesty.example.httpserver.spring;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Created by adol on 17-2-24.
+ */
+@Configuration
+//@ImportResource({"classpath:example.xml"})
+@ComponentScan({"org.nesty.core.server.springplus", "org.nesty.example.httpserver.spring"})
+public class EnvConfig {
+
+    @Bean
+    public ExampleBean getExampleBean() {
+        ExampleBean bean = new ExampleBean();
+        bean.msg = "programmer spring";
+        return bean;
+    }
+}

--- a/example/src/main/java/org/nesty/example/httpserver/spring/ExampleBean.java
+++ b/example/src/main/java/org/nesty/example/httpserver/spring/ExampleBean.java
@@ -1,0 +1,8 @@
+package org.nesty.example.httpserver.spring;
+
+/**
+ * Created by adol on 17-2-24.
+ */
+public class ExampleBean {
+    public String msg;
+}

--- a/example/src/main/java/org/nesty/example/httpserver/spring/SpringController.java
+++ b/example/src/main/java/org/nesty/example/httpserver/spring/SpringController.java
@@ -1,0 +1,31 @@
+package org.nesty.example.httpserver.spring;
+
+import org.nesty.commons.annotations.RequestMapping;
+import org.nesty.commons.constant.http.RequestMethod;
+import org.nesty.example.httpserver.spring.ExampleBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.nesty.commons.annotations.Controller;
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by adol on 17-2-24.
+ */
+@Component
+@Controller
+@RequestMapping("/hello")
+public class SpringController {
+    @Autowired
+    ExampleBean exampleBean;
+
+    @RequestMapping(value = "/", method = RequestMethod.GET)
+    public Map<String, Object> hello() {
+         Map<String, Object> map = new HashMap<String, Object>();
+         map.put("msg", exampleBean.msg);
+
+         return map;
+    }
+}


### PR DESCRIPTION
增加对spring的支持, 使nesty的controller和interceptor支持autowire spring bean

用法:

通过java类配置spring bean
```
@Configuration
@ImportResource({"classpath:application-hsf-client.xml", "classpath:secret.xml"})
@ComponentScan({"com.ump.udp.api.util", "com.ump.udp.api.handler", "org.nesty.core.server.springplus"})
public class EnvBean {
}
```

在configuration中添加"org.nesty.core.server.springplus"
在controller和interceptor的类上添加@Component的spring annotation